### PR TITLE
Adds getBytesRead() to JavaInflater interface/impls

### DIFF
--- a/src/main/java/com/nukkitx/natives/zlib/Inflater.java
+++ b/src/main/java/com/nukkitx/natives/zlib/Inflater.java
@@ -17,6 +17,8 @@ public interface Inflater extends Native {
 
     void reset();
 
+    long getBytesRead();
+
     interface Factory {
         Inflater newInstance(boolean nowrap);
     }

--- a/src/main/java/com/nukkitx/natives/zlib/Java11Inflater.java
+++ b/src/main/java/com/nukkitx/natives/zlib/Java11Inflater.java
@@ -37,6 +37,11 @@ public class Java11Inflater implements Inflater {
     }
 
     @Override
+    public long getBytesRead() {
+        return this.inflater.getBytesRead();
+    }
+
+    @Override
     public void free() {
         this.inflater.end();
     }

--- a/src/main/java/com/nukkitx/natives/zlib/JavaInflater.java
+++ b/src/main/java/com/nukkitx/natives/zlib/JavaInflater.java
@@ -54,6 +54,11 @@ public class JavaInflater implements Inflater {
     }
 
     @Override
+    public long getBytesRead() {
+        return this.inflater.getBytesRead();
+    }
+
+    @Override
     public void free() {
         this.inflater.end();
     }


### PR DESCRIPTION
Adds getBytesRead to JavaInflater interface and implementations for use in changes to Protocol WrapperSerializer.